### PR TITLE
fix signature error

### DIFF
--- a/NCMB/NCMBRequest/NCMBRequest.m
+++ b/NCMB/NCMBRequest/NCMBRequest.m
@@ -122,7 +122,7 @@ static NSString *const signatureVersion   = @"SignatureVersion=2";
                       signatureVersion,
                       [NSString stringWithFormat:@"%@=%@", appKeyField, self.applicationKey],
                       [NSString stringWithFormat:@"%@=%@", timestampField, timestamp]];
-    if (components.percentEncodedQuery != nil) {
+    if (components.percentEncodedQuery != nil && components.percentEncodedQuery.length > 0) {
         if ([@"GET" isEqualToString:method]) {
             self.signature = [self.signature stringByAppendingString:[NSString stringWithFormat:@"&%@", components.percentEncodedQuery]];
         }


### PR DESCRIPTION
## 概要(Summary)
- Fixed #155

条件を指定せずにQueryを実行するとエラー（E403002）が発生する障害を修正しました。


エラーコード | エラーメッセージ | 内容
-- | -- | --
E403002 | Unauthorized operations for {0}. | コラボレータ/管理者（サポート）権限なし

## 動作確認手順(Step for Confirmation)
以下のコードを実行した場合、常に検索に失敗します。  
なお、 #155 に記載されているように`query.whereKeyExists`を検索の前に実行した場合は成功します。

```Objective-C
let query = NCMBPush.query()
        
/** 条件を入れる場合はここに書きます **/
// query.whereKeyExists("title")
        
// 検索を実施
query.findObjectsInBackgroundWithBlock({(NSArray objects, NSError error) in
    if (error != nil){
        // 検索失敗時の処理
        
    }else{
        // 検索成功時の処理
        print(objects) // (例)検索結果を表示する
    }
})
```
